### PR TITLE
fix: custom path upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Request Parameters :
 * **region (type: String):** indicates the geographical server location (e.g us-east-1, eu-west-1a)
 * **file (type: String):** complete path of the file to be uploaded is passed on as a parameter
 * **bucket (type: String):** uniquely identifies the bucket where the file should be uploaded
+* **objectNameOverride (type: String):** Optional parameter, if given, the file name in wasabi will be overridden.
 
 Please refer to https://docs.aws.amazon.com/sdk-for-javascript/index.html for more details.
 
@@ -48,6 +49,9 @@ import wasabi from '@aicore/wasabi_storage_module.js';
 
 //Example for uploading file to linode object storage
 const response = await wasabi.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName);
+
+//Example if you want to change the file name in wasabi/ provide suctom upload location
+const response = await wasabi.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInWasabi);
 ```
 
 ### **2. getObject**

--- a/src/wasabi_storage_module.js
+++ b/src/wasabi_storage_module.js
@@ -22,22 +22,24 @@ const BASE_LINODE_URL_SUFFIX = '.wasabisys.com';
 /**
  * Wasabi Storage Helper Module to upload a file to object storage. The file is uploaded using
  * AWS S3 Client. Please refer to https://docs.aws.amazon.com/sdk-for-javascript/index.html for more details.
- * 
+ *
  * @param accessKeyId bucket specific unique identifier required for authentication
  * @param secretAccessKey user specific unique identifier required for authentication
  * @param region indicates the geographical server location (e.g us-east-1, eu-west-1a)
  * @param file complete path of the file to be uploaded is passed on as a parameter
  * @param bucket uniquely identifies the bucket where the file should be uploaded
+ * @param objectNameOverride If provided, the file will be uploaded with the given object name. Use this to provide
+ * custom file names and paths in wasabi.
  * @returns {Promise<void>}
  */
- async function uploadFileToBucket(accessKeyId, secretAccessKey, region, file, bucket) {
+ async function uploadFileToBucket(accessKeyId, secretAccessKey, region, file, bucket, objectNameOverride) {
     if (!accessKeyId || !secretAccessKey || !region || !file || !bucket) {
         throw new Error("Invalid parameter value: accessKeyId, secretAccessKey, region, filePath " +
         "and bucketName are required parameters");
     }
 
     const response = await s3Client.uploadFileToBucket(accessKeyId,
-        secretAccessKey, region, file, bucket, BASE_LINODE_URL_SUFFIX);
+        secretAccessKey, region, file, bucket, BASE_LINODE_URL_SUFFIX, objectNameOverride);
     console.log("Object Upload Response : " + JSON.stringify(response));
     return response;
 }
@@ -45,25 +47,25 @@ const BASE_LINODE_URL_SUFFIX = '.wasabisys.com';
 /**
  * Module to get the object data. The path of the file to be retrieved is
  * passed on as a parameter and the obejct stream is fetched using AWS S3 client.
- * 
+ *
  * @param accessKeyId bucket specific unique identifier required for authentication
  * @param secretAccessKey user specific unique identifier required for authentication
  * @param region indicates the geographical server location (e.g us-east-1, eu-west-1a)
  * @param bucketName uniquely identifies the bucket where the file should be uploaded
  * @param objectName object to be retrieved is passed on as a parameter
- * @returns getObjectResponse 
+ * @returns getObjectResponse
  */
 async function fetchObject(accessKeyId, secretAccessKey, region, bucketName, objectName) {
     if (!region || !bucketName || !objectName) {
         throw new Error("Invalid parameter value: accessToken, region, fileName " +
         "and bucketName are required parameters");
     }
-    const response = await s3Client.getObject(accessKeyId, secretAccessKey, region, 
+    const response = await s3Client.getObject(accessKeyId, secretAccessKey, region,
         bucketName, objectName, BASE_LINODE_URL_SUFFIX);
-    
+
     if (!response || !response.Body || !response.Body.data) {
         throw new Error("Invalid Response: Body or Body.Data is missing");
-    }    
+    }
 
     console.log("Object Fetch Response : " + JSON.stringify(response));
     return response.Body.data;


### PR DESCRIPTION
Add support to override filenames of uploaded file in wasabi
```js
//Example if you want to change the file name in wasabi/ provide suctom upload location
const response = await wasabi.uploadFileToBucket(accessKey, secretKey, region, fileName, bucketName, customPathInWasabi);
```
